### PR TITLE
Fix chair centering bug

### DIFF
--- a/public/script/index.js
+++ b/public/script/index.js
@@ -301,22 +301,16 @@ function manageWindowResize() {
 // set initial values: 
   console.log("setting initial theater size") 
   let initialVideoWrapperWidth = $('.video-wrapper').css('width')
-  let initialChairWidth = $('.chair').css('width')
   let mediaQuery = window.matchMedia("(max-width: 500px)")
   let initialFilmButtonWidth = (mediaQuery.matches) ? "33vw" : "12rem"
   $('.video-screen').css({'height': `calc(${initialVideoWrapperWidth} * .5625)`})
-  $('.chair-button-wrapper').css({'transform': `translateX(calc((${initialChairWidth} * 15 - 100vw)* -.5))`})
   $('.film-button-wrapper').css({'width': `calc(${initialFilmButtonWidth} * 18)`,'transform': `translateX(calc(((${initialFilmButtonWidth} * 18) - 100vw)* -.5))`})
 // Update values if window resized:
   window.onresize = function() {
     console.log("Window size changed... resizing theater")
-    $('.chair-buttons').css({"display": "block"}) 
-    // Chairs must be visible to obtain accurate .css('width')
-    let chairWidth = $('.chair').css('width')
     let videoWrapperWidth = $('.video-wrapper').css('width')
     let filmButtonWidth = (mediaQuery.matches) ? "33vw" : "12rem"
     $('.video-screen').css({'height': `calc(${videoWrapperWidth} * .5625)`})
-    $('.chair-button-wrapper').css({'transform': `translateX(calc((${chairWidth} * 15 - 100vw)* -.5))`})
     $('.film-button-wrapper').css({'width': `calc(${filmButtonWidth} * 18)`, 'transform': `translateX(calc(((${filmButtonWidth} * 18) - 100vw)* -.5))`})
   }
 }

--- a/public/style/index.css
+++ b/public/style/index.css
@@ -121,7 +121,7 @@ nav {
 .chair {
   float: left;
   width: 20rem;
-  max-width: calc(33vw);
+  max-width: calc(33vw); /* shrinks chair buttons if viewport width drops below 810px */
   height: calc(20rem / 2.1);
   max-height: calc(33vw / 2.1); /* prevents chairs from floating if screen becomes too tall */
   background:url(../image/chair-a1.png) 0 0 no-repeat;
@@ -227,9 +227,18 @@ button:active {
   padding-right: .7em;
 }
 .chair-button-wrapper {
-  width: 300rem;
-  transform: translateX(calc((300rem - 100vw)* -.5));
+  width: calc(33vw * 15); /* width of chair times number of chairs */
+  transform: translateX(calc(((33vw * 15) - 100vw)* -.5)); /* centers the element horizontally */
 }
+@media only screen and (min-width: 810px) {
+/* chairs are always 20rem wide on viewport-widths >= 810px */
+  .chair-button-wrapper {
+  width: 300rem; /* 15 chairs total times 20rem */
+  transform: translateX(calc((300rem - 100vw)* -.5)); /* centers the element horizontally */
+  }
+}
+
+
 .film-button-wrapper {
   top: 0px;
 }


### PR DESCRIPTION
In some circumstances, jQuery didn't always obtain the correct chair
width due to DOM rendering delays. Fixed by moving operation entirely
into CSS and calculating current values using media queries instead
of reading from the DOM. Faster, and now 100% reliable.